### PR TITLE
feat(sheet): usar RESP_ADM resolvido por cabeçalho

### DIFF
--- a/.github/agents/column-mapper.js
+++ b/.github/agents/column-mapper.js
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+// .github/agents/column-mapper.js
+// Scans repository .gs/.js/.html files for hard-coded numeric column indexes
+// and generates a report with suggestions to add HEADERS_COLS mappings.
+
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+function listFiles(dir) {
+  const out = [];
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const e of entries) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      if (['node_modules', '.git'].includes(e.name)) continue;
+      out.push(...listFiles(full));
+    } else {
+      if (full.endsWith('.gs') || full.endsWith('.js') || full.endsWith('.html')) out.push(full);
+    }
+  }
+  return out;
+}
+
+function scanFile(filePath) {
+  const txt = fs.readFileSync(filePath, 'utf8');
+  const lines = txt.split(/\r?\n/);
+  const findings = [];
+
+  const patterns = [
+    { name: 'getRange_numeric', re: /getRange\(\s*[^,]+,\s*\d+/ },
+    { name: 'getRange_two_numeric', re: /getRange\(\s*\d+\s*,\s*\d+/ },
+    { name: 'getValues_index', re: /getValues\(\)\s*\[\s*\d+\s*\]\s*\[\s*\d+\s*\]/ },
+    { name: 'array_index', re: /\[\s*\d+\s*\](?=\s*\[|\s*;|\s*,|\s*\)|\s*$)/ }
+  ];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    for (const p of patterns) {
+      if (p.re.test(line)) {
+        findings.push({ line: i+1, text: line.trim(), pattern: p.name });
+      }
+    }
+  }
+  return findings;
+}
+
+function suggestHeaderName(file, lineText) {
+  // Heuristic: try to extract a probable column variable name near the code
+  // Fallback: generic suggestion including the numeric index found
+  const m = lineText.match(/\[\s*(\d+)\s*\]/) || lineText.match(/getRange\(.*,(\s*\d+)/);
+  const idx = m ? m[1].replace(/[^0-9]/g,'') : null;
+  if (idx) return `SUGGESTED_HEADER_COL_${idx}`;
+  return 'SUGGESTED_HEADER_NAME';
+}
+
+function run() {
+  console.log('Scanning repository for numeric column index usages...');
+  const files = listFiles(repoRoot);
+  const report = [];
+  for (const f of files) {
+    const rel = path.relative(repoRoot, f);
+    try {
+      const findings = scanFile(f);
+      if (findings.length) {
+        for (const fin of findings) {
+          report.push({ file: rel, line: fin.line, code: fin.text, pattern: fin.pattern, suggestion: suggestHeaderName(rel, fin.text) });
+        }
+      }
+    } catch (e) {
+      console.error('Failed to scan', rel, e.message);
+    }
+  }
+
+  const outDir = path.join(repoRoot, 'reports');
+  if (!fs.existsSync(outDir)) fs.mkdirSync(outDir);
+
+  const mdPath = path.join(outDir, 'column-index-report.md');
+  const jsonPath = path.join(outDir, 'column-index-report.json');
+
+  const now = new Date().toISOString();
+  let md = `# Column Index Report\n\nGenerated: ${now}\n\n`;
+  if (!report.length) {
+    md += 'No obvious numeric column index usages were found. Good job!\n';
+  } else {
+    md += `Found ${report.length} potential usages:\n\n`;
+    for (const r of report) {
+      md += `- ${r.file}:${r.line} — pattern: ${r.pattern} — suggestion: ${r.suggestion}\n  \n    Code: \`${r.code.replace(/`/g,'\\`')}\`\n\n`;
+    }
+    md += '\n\nSuggested next steps:\n- For each occurrence, inspect and replace numeric index with resolveSheetColumns_(sheet, CONFIG.HEADERS_COLS.<SHEET>, CONFIG.COLUMNS.<SHEET>).\n- Add a descriptive key to CONFIG.HEADERS_COLS for the header text you will use.\n';
+  }
+
+  fs.writeFileSync(mdPath, md, 'utf8');
+  fs.writeFileSync(jsonPath, JSON.stringify({ generated: now, items: report }, null, 2), 'utf8');
+
+  console.log('Report written to', mdPath, jsonPath);
+}
+
+run();

--- a/AGENT-LOGS.md
+++ b/AGENT-LOGS.md
@@ -36,3 +36,4 @@ Instruções para o outro agente (append seguro):
 
 Obs: este arquivo foi criado automaticamente para suportar monitoramento entre agentes. Mantê-lo curto e legível.
 - 2026-04-08T19:10:08.091Z | Copilot-Local | REVALIDATE_POST_SORT | Revalidação de subcategorias após ordenação | commit: 0577002 
+- 2026-04-08T20:12:07.017Z | Copilot-Local | REMOVE_LIMPO_OCORRENCIAS | Remove 'LIMPO' em ocorrências automatizadas | commit: c9cee9d 

--- a/reports/column-index-report.json
+++ b/reports/column-index-report.json
@@ -1,0 +1,887 @@
+{
+  "generated": "2026-04-08T21:06:01.639Z",
+  "items": [
+    {
+      "file": "scripts\\Dashboard.gs",
+      "line": 44,
+      "code": "const dadosInfo = abaInfo.getRange(iniInfo, 1, lastInfo - iniInfo + 1, maxColInfo).getDisplayValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\Dashboard.gs",
+      "line": 83,
+      "code": "const dadosPed = abaPedidos.getRange(iniPed, 1, lastPed - iniPed + 1, maxColPed).getDisplayValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\Dashboard.gs",
+      "line": 112,
+      "code": "const dadosOco = abaOcor.getRange(iniOco, 1, lastOco - iniOco + 1, maxColOco).getDisplayValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\Main.gs",
+      "line": 93,
+      "code": "processarIntervaloAparaB_(aba, aba.getRange(linhaCorte, 1, aba.getLastRow() - linhaCorte + 1, 1));",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\Main.gs",
+      "line": 204,
+      "code": "const dados = obra.getRange(ini, 1, numRows, maxCol).getValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SheetEntrega.gs",
+      "line": 34,
+      "code": "const dados = entrega.getRange(primeiraLinha, 1, numLinhas, maxCol).getValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SheetInfoGerais.gs",
+      "line": 67,
+      "code": "const dadosEmpUni = info.getRange(primeiraLinha, 1, numLinhas, maxColInfo).getDisplayValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SheetInfoGerais.gs",
+      "line": 114,
+      "code": "const origem = info.getRange(linhaMolde, 1, 1, maxCols);",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SheetInfoGerais.gs",
+      "line": 115,
+      "code": "const alvo = info.getRange(linhaIni, 1, qtd, maxCols);",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SheetInfoGerais.gs",
+      "line": 136,
+      "code": "info.getRange(linhaIni, 1, qtd, colFimDados).clearContent();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SheetInfoGerais.gs",
+      "line": 141,
+      "code": "processarIntervaloAparaB_(info, info.getRange(linhaIni, 1, qtd, 1));",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SheetInfoGerais.gs",
+      "line": 179,
+      "code": "const dadosObra = abaObra.getRange(iniObra, 1, lastObra - iniObra + 1, maxColObra)",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SheetInfoGerais.gs",
+      "line": 208,
+      "code": "const dadosInfo = abaInfo.getRange(iniInfo, 1, lastInfo - iniInfo + 1, maxColInfo)",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SheetInfoGerais.gs",
+      "line": 232,
+      "code": "console.log(\"Indicador de atrasos atualizado: \" + novosResumos.filter(r => r[0]).length + \" unidade(s) com atraso.\");",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_0"
+    },
+    {
+      "file": "scripts\\SheetObra.gs",
+      "line": 93,
+      "code": ".filter(r => String(r[0]).trim() === cat && String(r[1]).trim() !== \"\")",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_0"
+    },
+    {
+      "file": "scripts\\SheetObra.gs",
+      "line": 94,
+      "code": ".map(r => String(r[1]).trim());",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SheetObra.gs",
+      "line": 114,
+      "code": "celulaSub.setValue(subcategorias[0]);",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_0"
+    },
+    {
+      "file": "scripts\\SheetObra.gs",
+      "line": 173,
+      "code": "const valsObra = obra.getRange(obraIni, 1, obraLast - obraIni + 1, Math.max(C_OBRA.EMP, C_OBRA.UNI)).getDisplayValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SheetObra.gs",
+      "line": 223,
+      "code": "const dadosPre = pre.getRange(preIni, 1, preLast - preIni + 1, lastColPre).getValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SheetObra.gs",
+      "line": 254,
+      "code": "linhaNova[C_OBRA.CAT - 1] = t[0];",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_0"
+    },
+    {
+      "file": "scripts\\SheetObra.gs",
+      "line": 255,
+      "code": "linhaNova[C_OBRA.SUB - 1] = t[1];",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SheetObra.gs",
+      "line": 256,
+      "code": "linhaNova[C_OBRA.ATRELADO - 1] = t[2];",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_2"
+    },
+    {
+      "file": "scripts\\SheetObra.gs",
+      "line": 274,
+      "code": "const rangeInsert = obra.getRange(iniLivre, 1, arrayLoteCompleto.length, numMaxColsLinha);",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SheetObra.gs",
+      "line": 300,
+      "code": "const vals = obra.getRange(linha, 1, 1, Math.max(C.CHAVE, C.ATRELADO)).getValues()[0];",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_0"
+    },
+    {
+      "file": "scripts\\SheetObra.gs",
+      "line": 300,
+      "code": "const vals = obra.getRange(linha, 1, 1, Math.max(C.CHAVE, C.ATRELADO)).getValues()[0];",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_0"
+    },
+    {
+      "file": "scripts\\SheetObra.gs",
+      "line": 319,
+      "code": "const dadosPed = abaPedidos.getRange(linhaPed, C_PED.STATUS, 1, C_PED.FORNECEDOR - C_PED.STATUS + 1).getValues()[0];",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_0"
+    },
+    {
+      "file": "scripts\\SheetObra.gs",
+      "line": 320,
+      "code": "obra.getRange(linha, C.STATUS).setValue(dadosPed[0]);",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_0"
+    },
+    {
+      "file": "scripts\\SheetObra.gs",
+      "line": 321,
+      "code": "obra.getRange(linha, C.FORNECEDOR).setValue(dadosPed[1]);",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SheetObra.gs",
+      "line": 431,
+      "code": "const dados = sheetObra.getRange(rowStart, 1, numRows, maxCol).getDisplayValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SheetOcorrencias.gs",
+      "line": 49,
+      "code": "const dados = ocorrencias.getRange(primeiraLinha, 1, numLinhas, maxCol).getValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SheetOcorrencias.gs",
+      "line": 99,
+      "code": ".filter(r => String(r[0]).trim() === cat && String(r[1]).trim() !== \"\")",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_0"
+    },
+    {
+      "file": "scripts\\SheetOcorrencias.gs",
+      "line": 100,
+      "code": ".map(r => String(r[1]).trim());",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SheetPedidos.gs",
+      "line": 106,
+      "code": "const nome = textoNormalizadoSemAcento_(f[0]);",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_0"
+    },
+    {
+      "file": "scripts\\SheetPedidos.gs",
+      "line": 139,
+      "code": "const dadosPedidos = sheet.getRange(rowStartAdjusted, 1, numRowsAdjusted, maxColPed).getValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SheetPedidos.gs",
+      "line": 157,
+      "code": "const dadosObra = abaObra.getRange(iniObra, 1, numRowsObra, maxColObra).getValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SheetPreliminar.gs",
+      "line": 42,
+      "code": "const dados = pre.getRange(primeiraLinha, 1, numLinhas, maxCol).getValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SheetPreliminar.gs",
+      "line": 86,
+      "code": "const dadosEmpUni = pre.getRange(primeiraLinha, 1, numLinhas, Math.max(C.EMP, C.UNI)).getDisplayValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SheetPreliminar.gs",
+      "line": 87,
+      "code": "const controles = pre.getRange(primeiraLinha, 1, numLinhas, ultimaColControle).getDisplayValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SheetPreliminar.gs",
+      "line": 89,
+      "code": "const cabecalhosChecklist = pre.getRange(linhaHeader, C.CHECKLIST_INI, 1, C.CHECKLIST_FIM - C.CHECKLIST_INI + 1).getDisplayValues()[0];",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_0"
+    },
+    {
+      "file": "scripts\\SheetPreliminar.gs",
+      "line": 263,
+      "code": "const dados = pre.getRange(primeiraLinha, 1, numLinhas, maxCol).getDisplayValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 22,
+      "code": "const dadosObra = sheetObra.getRange(rowStart, 1, numRows, C_OBRA.CHAVE).getValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 30,
+      "code": "dadosPedAll = abaPedidos.getRange(iniPed, 1, lastPed - iniPed + 1, C_PED.CHAVE).getValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 110,
+      "code": "abaPedidos.getRange(iniPed, 1, dadosPedAll.length, C_PED.CHAVE).setValues(dadosPedAll);",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 117,
+      "code": "abaPedidos.getRange(linhaDest, 1, 1, C_PED.CHAVE).setValues([dados]);",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 156,
+      "code": "const dadosObra = sheetObra.getRange(linhaIniObra, 1, numLinhasObra, C_OBRA.CHAVE).getValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 163,
+      "code": "dadosPed = abaPedidos.getRange(linhaIniPed, 1, numRowsPed, C_PED.CHAVE).getValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 239,
+      "code": "abaPedidos.getRange(linhaIniPed, 1, rowsParaLimpar, C_PED.CHAVE).clearContent();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 251,
+      "code": "abaPedidos.getRange(linhaIniPed, 1, listaFinalPedidos.length, C_PED.CHAVE).setValues(listaFinalPedidos);",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 277,
+      "code": "const dadosObra = sheetObra.getRange(rowStart, 1, numRows, maxColObra).getValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 295,
+      "code": "const dadosPed = abaPedidos.getRange(iniPed, 1, numRowsPed, maxColPed).getValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 331,
+      "code": "const chave = String(dados[i][0]).trim();",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_0"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 350,
+      "code": "if (String(chaves[i][0]).trim() === String(chave).trim()) return ini + i;",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_0"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 367,
+      "code": "if (String(chaves[i][0]).trim() === String(chave).trim()) return ini + i;",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_0"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 407,
+      "code": "const empOriginal = String(valsEmp[i][0]).trim();",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_0"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 418,
+      "code": ".filter(r => textoNormalizadoSemAcento_(r[0]) === empBusca)",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_0"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 419,
+      "code": ".map(r => String(r[1]).trim())",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 461,
+      "code": "const valsA = pre.getRange(linhaIni, 1, last - linhaIni + 1, 1).getDisplayValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 463,
+      "code": "if (CONFIG.STATUS.MARCADOR_BASE.test(valsA[i][0])) {",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_0"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 497,
+      "code": "range: abaPedidos.getRange(obterLinhaInicialPorAba(CONFIG.SHEETS.PEDIDOS), 1, abaPedidos.getLastRow(), 9),",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_9"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 522,
+      "code": "const registrosInfo = info.getRange(linhaInicialInfo, 1, lastInfo - linhaInicialInfo + 1, maxColInfo).getValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 542,
+      "code": "? pre.getRange(linhaHeaderPre, 1, 1, lastColPre).getDisplayValues()[0]",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_0"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 542,
+      "code": "? pre.getRange(linhaHeaderPre, 1, 1, lastColPre).getDisplayValues()[0]",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_0"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 559,
+      "code": "const dadosPre = pre.getRange(linhaInicialPre, 1, lastPre - linhaInicialPre + 1, 2).getDisplayValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_2"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 602,
+      "code": "const origem = pre.getRange(linhaMolde, 1, 1, maxCols);",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 603,
+      "code": "const alvo = pre.getRange(linhaInicialPre, 1, qtd, maxCols);",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 658,
+      "code": "const minRow = linhas[0];",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_0"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 674,
+      "code": "pre.getRange(minRow, 2, maxRow - minRow + 1, 1).clearDataValidations();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 693,
+      "code": "const valoresA = abaPedidos.getRange(linhaInicial, 1, limiteBusca - linhaInicial + 1, 1).getDisplayValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 717,
+      "code": "const valsA = aba.getRange(linhaInicial, 1, last - linhaInicial + 1, 1).getDisplayValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 752,
+      "code": "const dados = info.getRange(linhaIniInfo, 1, numLinhas, numCols).getDisplayValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 835,
+      "code": "const emp = String(existentes[i][0]).trim().toUpperCase();",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_0"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 836,
+      "code": "const uni = String(existentes[i][1]).trim();",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 843,
+      "code": "const emp = String(listaEmpUni[i][0]).trim();",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_0"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 844,
+      "code": "const uni = String(listaEmpUni[i][1]).trim();",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 894,
+      "code": "const c = String(chavesObra[i][0]).trim();",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_0"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 911,
+      "code": "const chavePed = String(chavesPedidos[i][0]).trim();",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_0"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 972,
+      "code": "const dados = sheet.getRange(rowStart, 1, numRows, 2).getValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_2"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 1001,
+      "code": "const dadosOco = abaOco.getRange(iniOco, 1, lastOco - iniOco + 1, Math.max(C_OCO.EMP, C_OCO.UNI, C_OCO.STATUS_GERAL)).getValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 1024,
+      "code": "const rangePre = abaPre.getRange(iniPre, 1, numRowsPre, maxColPre);",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 1071,
+      "code": "const dadosPre = pre.getRange(iniPre, 1, lastPre - iniPre + 1, maxColPre).getValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 1100,
+      "code": "const rangeInfo = info.getRange(iniInfo, 1, lastInfo - iniInfo + 1, Math.max(C_INFO.EMP, C_INFO.UNI));",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 1162,
+      "code": "const dadosEdicao = abaPedidos.getRange(rowStart, 1, numRows, abaPedidos.getLastColumn()).getValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 1184,
+      "code": "const rangeObra = abaObra.getRange(iniObra, 1, lastObra - iniObra + 1, C_OBRA.CHAVE);",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 1223,
+      "code": "range: abaPedidos.getRange(obterLinhaInicialPorAba(CONFIG.SHEETS.PEDIDOS), 1, abaPedidos.getLastRow(), 9),",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_9"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 1255,
+      "code": "const dadosEntrega = entrega.getRange(rowStart, 1, numRows, Math.max(C_ENTREGA.EMP, C_ENTREGA.UNI)).getValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 1263,
+      "code": "const dadosPre = pre.getRange(preIni, 1, preLast - preIni + 1, Math.max(C_PRE.EMP, C_PRE.UNI, C_PRE.RESP_OPR, C_PRE.RESP_ADM)).getValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 1313,
+      "code": "range: entrega.getRange(ini, 1, last - ini + 1, 1), // simula alcance englobando coluna A (EMP)",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 1420,
+      "code": "const dados = abaPre.getRange(ini, 1, last - ini + 1, Math.max(C.EMP, C.UNI, C.DATA_LOTE)).getValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 1461,
+      "code": "const dados   = sheetObra.getRange(rowStart, 1, numRows, numCols).getValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 1528,
+      "code": "const dadosEnt = entrega.getRange(iniEnt, 1, lastEnt - iniEnt + 1, Math.max(C_ENT.UNI, C_ENT.STATUS_GERAL || 0)).getValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 1543,
+      "code": "const rangeInfo = info.getRange(iniInfo, 1, lastInfo - iniInfo + 1, Math.max(C_INFO.EMP, C_INFO.UNI));",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 1576,
+      "code": "range: obra.getRange(ini, 1, last - ini + 1, 1),",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 1670,
+      "code": "{ range: obra.getRange(ini, 1, last - ini + 1, 1), source: ss },",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 1703,
+      "code": "const fakeEvent = { range: info.getRange(iniInfo, 1, lastInfo - iniInfo + 1, 1) };",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 1732,
+      "code": "const dadosInfo = info.getRange(rowStart, 1, numRows, maxColInfo).getDisplayValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 1757,
+      "code": "const dadosObra = obra.getRange(iniObra, 1, numObraRows, maxColObra).getValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 1824,
+      "code": "const dados = sheetObra.getRange(rowStart, 1, numRows, maxCol).getValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 1850,
+      "code": "range: obra.getRange(ini, 1, last - ini + 1, 1),",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 1882,
+      "code": "const dadosInfo = abaInfo.getRange(iniInfo, 1, lastInfo - iniInfo + 1, maxColInfo).getDisplayValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 1905,
+      "code": "const dadosPre = abaPre.getRange(iniPre, 1, lastPre - iniPre + 1, maxColPre).getDisplayValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 1914,
+      "code": "etiquetas.push([999999]); // Marcador vai pro fundo absoluto",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_999999"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 1923,
+      "code": "etiquetas.push([99999]); // Itens não listados, brancos ou lixos caem pro fundo",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_99999"
+    },
+    {
+      "file": "scripts\\SyncLogic.gs",
+      "line": 1936,
+      "code": "const rangeTotal = abaPre.getRange(iniPre, 1, etiquetas.length, colTemp);",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\Tests.gs",
+      "line": 79,
+      "code": "sheetObra.getRange(novaLinhaObra, 1, 1, dadosTesteObra[0].length).setValues(dadosTesteObra);",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_0"
+    },
+    {
+      "file": "scripts\\Tests.gs",
+      "line": 83,
+      "code": "range: sheetObra.getRange(novaLinhaObra, 1, 1, C_OBRA.ATRELADO),",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\Tests.gs",
+      "line": 94,
+      "code": "const dadosPedidos = abaPedidos.getRange(iniPed, 1, Math.max(1, lastPed - iniPed + 1), C_PED.EMP).getDisplayValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\Tests.gs",
+      "line": 116,
+      "code": "const dadosPedidos2Before = abaPedidos.getRange(iniPed, 1, Math.max(1, lastPed2Before - iniPed + 1), C_PED.EMP).getDisplayValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\Tests.gs",
+      "line": 125,
+      "code": "sheetObra.getRange(novaLinhaObra2, 1, 1, dadosTesteObra2[0].length).setValues(dadosTesteObra2);",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_0"
+    },
+    {
+      "file": "scripts\\Tests.gs",
+      "line": 128,
+      "code": "range: sheetObra.getRange(novaLinhaObra2, 1, 1, C_OBRA.ATRELADO),",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\Tests.gs",
+      "line": 136,
+      "code": "const dadosPedidos2After = abaPedidos.getRange(iniPed, 1, Math.max(1, lastPed2After - iniPed + 1), C_PED.EMP).getDisplayValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\Tests.gs",
+      "line": 364,
+      "code": "const status = dados[i][1];",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\Utils.gs",
+      "line": 71,
+      "code": "const dia = Number(m[1]);",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\Utils.gs",
+      "line": 72,
+      "code": "const mes = Number(m[2]) - 1;",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_2"
+    },
+    {
+      "file": "scripts\\Utils.gs",
+      "line": 73,
+      "code": "let ano = Number(m[3]);",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_3"
+    },
+    {
+      "file": "scripts\\Utils.gs",
+      "line": 110,
+      "code": "const cabecalhos = aba.getRange(linhaBusca, 1, 1, lastCol).getDisplayValues()[0];",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_0"
+    },
+    {
+      "file": "scripts\\Utils.gs",
+      "line": 110,
+      "code": "const cabecalhos = aba.getRange(linhaBusca, 1, 1, lastCol).getDisplayValues()[0];",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_0"
+    },
+    {
+      "file": "scripts\\Utils.gs",
+      "line": 143,
+      "code": "const dados = aba.getRange(linhaInicialDados, 1, numRows, lastCol).getDisplayValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\Utils.gs",
+      "line": 220,
+      "code": "if (String(values[i][0]).trim() !== \"\") return i + 1;",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_0"
+    },
+    {
+      "file": "scripts\\Utils.gs",
+      "line": 385,
+      "code": "const dadosInfo = info.getRange(iniInfo, 1, lastInfo - iniInfo + 1, maxColInfo).getDisplayValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\Utils.gs",
+      "line": 399,
+      "code": "const dadosChaveObra = obra.getRange(iniObra, 1, total, maxColChave).getDisplayValues();",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\Utils.gs",
+      "line": 444,
+      "code": "const rangeSort = obra.getRange(iniObra, 1, total, colSeqGlobal);",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\Utils.gs",
+      "line": 459,
+      "code": "const spacerRange = obra.getRange(spacerRow, 1, 1, obra.getLastColumn());",
+      "pattern": "getRange_numeric",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "scripts\\Utils.gs",
+      "line": 460,
+      "code": "const spacerVals = spacerRange.getValues()[0];",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_0"
+    },
+    {
+      "file": "tests.js",
+      "line": 230,
+      "code": "suite4.assertEqual(dados[0][0], \"EMPREENDIMENTO\", \"Cabeçalho correto\");",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_0"
+    },
+    {
+      "file": "tests.js",
+      "line": 231,
+      "code": "suite4.assertEqual(dados[1][0], \"MODERN BUNTANTÃ\", \"Primeiro EMP correto\");",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    },
+    {
+      "file": "tests.js",
+      "line": 239,
+      "code": "suite4.assertEqual(dados[1][1], \"11999999999\", \"Contato do primeiro fornecedor\");",
+      "pattern": "array_index",
+      "suggestion": "SUGGESTED_HEADER_COL_1"
+    }
+  ]
+}

--- a/reports/column-index-report.md
+++ b/reports/column-index-report.md
@@ -1,0 +1,515 @@
+# Column Index Report
+
+Generated: 2026-04-08T21:06:01.639Z
+
+Found 126 potential usages:
+
+- scripts\Dashboard.gs:44 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dadosInfo = abaInfo.getRange(iniInfo, 1, lastInfo - iniInfo + 1, maxColInfo).getDisplayValues();`
+
+- scripts\Dashboard.gs:83 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dadosPed = abaPedidos.getRange(iniPed, 1, lastPed - iniPed + 1, maxColPed).getDisplayValues();`
+
+- scripts\Dashboard.gs:112 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dadosOco = abaOcor.getRange(iniOco, 1, lastOco - iniOco + 1, maxColOco).getDisplayValues();`
+
+- scripts\Main.gs:93 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `processarIntervaloAparaB_(aba, aba.getRange(linhaCorte, 1, aba.getLastRow() - linhaCorte + 1, 1));`
+
+- scripts\Main.gs:204 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dados = obra.getRange(ini, 1, numRows, maxCol).getValues();`
+
+- scripts\SheetEntrega.gs:34 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dados = entrega.getRange(primeiraLinha, 1, numLinhas, maxCol).getValues();`
+
+- scripts\SheetInfoGerais.gs:67 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dadosEmpUni = info.getRange(primeiraLinha, 1, numLinhas, maxColInfo).getDisplayValues();`
+
+- scripts\SheetInfoGerais.gs:114 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const origem = info.getRange(linhaMolde, 1, 1, maxCols);`
+
+- scripts\SheetInfoGerais.gs:115 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const alvo = info.getRange(linhaIni, 1, qtd, maxCols);`
+
+- scripts\SheetInfoGerais.gs:136 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `info.getRange(linhaIni, 1, qtd, colFimDados).clearContent();`
+
+- scripts\SheetInfoGerais.gs:141 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `processarIntervaloAparaB_(info, info.getRange(linhaIni, 1, qtd, 1));`
+
+- scripts\SheetInfoGerais.gs:179 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dadosObra = abaObra.getRange(iniObra, 1, lastObra - iniObra + 1, maxColObra)`
+
+- scripts\SheetInfoGerais.gs:208 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dadosInfo = abaInfo.getRange(iniInfo, 1, lastInfo - iniInfo + 1, maxColInfo)`
+
+- scripts\SheetInfoGerais.gs:232 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_0
+  
+    Code: `console.log("Indicador de atrasos atualizado: " + novosResumos.filter(r => r[0]).length + " unidade(s) com atraso.");`
+
+- scripts\SheetObra.gs:93 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_0
+  
+    Code: `.filter(r => String(r[0]).trim() === cat && String(r[1]).trim() !== "")`
+
+- scripts\SheetObra.gs:94 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `.map(r => String(r[1]).trim());`
+
+- scripts\SheetObra.gs:114 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_0
+  
+    Code: `celulaSub.setValue(subcategorias[0]);`
+
+- scripts\SheetObra.gs:173 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const valsObra = obra.getRange(obraIni, 1, obraLast - obraIni + 1, Math.max(C_OBRA.EMP, C_OBRA.UNI)).getDisplayValues();`
+
+- scripts\SheetObra.gs:223 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dadosPre = pre.getRange(preIni, 1, preLast - preIni + 1, lastColPre).getValues();`
+
+- scripts\SheetObra.gs:254 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_0
+  
+    Code: `linhaNova[C_OBRA.CAT - 1] = t[0];`
+
+- scripts\SheetObra.gs:255 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `linhaNova[C_OBRA.SUB - 1] = t[1];`
+
+- scripts\SheetObra.gs:256 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_2
+  
+    Code: `linhaNova[C_OBRA.ATRELADO - 1] = t[2];`
+
+- scripts\SheetObra.gs:274 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const rangeInsert = obra.getRange(iniLivre, 1, arrayLoteCompleto.length, numMaxColsLinha);`
+
+- scripts\SheetObra.gs:300 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_0
+  
+    Code: `const vals = obra.getRange(linha, 1, 1, Math.max(C.CHAVE, C.ATRELADO)).getValues()[0];`
+
+- scripts\SheetObra.gs:300 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_0
+  
+    Code: `const vals = obra.getRange(linha, 1, 1, Math.max(C.CHAVE, C.ATRELADO)).getValues()[0];`
+
+- scripts\SheetObra.gs:319 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_0
+  
+    Code: `const dadosPed = abaPedidos.getRange(linhaPed, C_PED.STATUS, 1, C_PED.FORNECEDOR - C_PED.STATUS + 1).getValues()[0];`
+
+- scripts\SheetObra.gs:320 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_0
+  
+    Code: `obra.getRange(linha, C.STATUS).setValue(dadosPed[0]);`
+
+- scripts\SheetObra.gs:321 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `obra.getRange(linha, C.FORNECEDOR).setValue(dadosPed[1]);`
+
+- scripts\SheetObra.gs:431 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dados = sheetObra.getRange(rowStart, 1, numRows, maxCol).getDisplayValues();`
+
+- scripts\SheetOcorrencias.gs:49 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dados = ocorrencias.getRange(primeiraLinha, 1, numLinhas, maxCol).getValues();`
+
+- scripts\SheetOcorrencias.gs:99 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_0
+  
+    Code: `.filter(r => String(r[0]).trim() === cat && String(r[1]).trim() !== "")`
+
+- scripts\SheetOcorrencias.gs:100 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `.map(r => String(r[1]).trim());`
+
+- scripts\SheetPedidos.gs:106 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_0
+  
+    Code: `const nome = textoNormalizadoSemAcento_(f[0]);`
+
+- scripts\SheetPedidos.gs:139 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dadosPedidos = sheet.getRange(rowStartAdjusted, 1, numRowsAdjusted, maxColPed).getValues();`
+
+- scripts\SheetPedidos.gs:157 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dadosObra = abaObra.getRange(iniObra, 1, numRowsObra, maxColObra).getValues();`
+
+- scripts\SheetPreliminar.gs:42 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dados = pre.getRange(primeiraLinha, 1, numLinhas, maxCol).getValues();`
+
+- scripts\SheetPreliminar.gs:86 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dadosEmpUni = pre.getRange(primeiraLinha, 1, numLinhas, Math.max(C.EMP, C.UNI)).getDisplayValues();`
+
+- scripts\SheetPreliminar.gs:87 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const controles = pre.getRange(primeiraLinha, 1, numLinhas, ultimaColControle).getDisplayValues();`
+
+- scripts\SheetPreliminar.gs:89 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_0
+  
+    Code: `const cabecalhosChecklist = pre.getRange(linhaHeader, C.CHECKLIST_INI, 1, C.CHECKLIST_FIM - C.CHECKLIST_INI + 1).getDisplayValues()[0];`
+
+- scripts\SheetPreliminar.gs:263 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dados = pre.getRange(primeiraLinha, 1, numLinhas, maxCol).getDisplayValues();`
+
+- scripts\SyncLogic.gs:22 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dadosObra = sheetObra.getRange(rowStart, 1, numRows, C_OBRA.CHAVE).getValues();`
+
+- scripts\SyncLogic.gs:30 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `dadosPedAll = abaPedidos.getRange(iniPed, 1, lastPed - iniPed + 1, C_PED.CHAVE).getValues();`
+
+- scripts\SyncLogic.gs:110 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `abaPedidos.getRange(iniPed, 1, dadosPedAll.length, C_PED.CHAVE).setValues(dadosPedAll);`
+
+- scripts\SyncLogic.gs:117 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `abaPedidos.getRange(linhaDest, 1, 1, C_PED.CHAVE).setValues([dados]);`
+
+- scripts\SyncLogic.gs:156 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dadosObra = sheetObra.getRange(linhaIniObra, 1, numLinhasObra, C_OBRA.CHAVE).getValues();`
+
+- scripts\SyncLogic.gs:163 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `dadosPed = abaPedidos.getRange(linhaIniPed, 1, numRowsPed, C_PED.CHAVE).getValues();`
+
+- scripts\SyncLogic.gs:239 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `abaPedidos.getRange(linhaIniPed, 1, rowsParaLimpar, C_PED.CHAVE).clearContent();`
+
+- scripts\SyncLogic.gs:251 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `abaPedidos.getRange(linhaIniPed, 1, listaFinalPedidos.length, C_PED.CHAVE).setValues(listaFinalPedidos);`
+
+- scripts\SyncLogic.gs:277 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dadosObra = sheetObra.getRange(rowStart, 1, numRows, maxColObra).getValues();`
+
+- scripts\SyncLogic.gs:295 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dadosPed = abaPedidos.getRange(iniPed, 1, numRowsPed, maxColPed).getValues();`
+
+- scripts\SyncLogic.gs:331 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_0
+  
+    Code: `const chave = String(dados[i][0]).trim();`
+
+- scripts\SyncLogic.gs:350 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_0
+  
+    Code: `if (String(chaves[i][0]).trim() === String(chave).trim()) return ini + i;`
+
+- scripts\SyncLogic.gs:367 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_0
+  
+    Code: `if (String(chaves[i][0]).trim() === String(chave).trim()) return ini + i;`
+
+- scripts\SyncLogic.gs:407 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_0
+  
+    Code: `const empOriginal = String(valsEmp[i][0]).trim();`
+
+- scripts\SyncLogic.gs:418 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_0
+  
+    Code: `.filter(r => textoNormalizadoSemAcento_(r[0]) === empBusca)`
+
+- scripts\SyncLogic.gs:419 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `.map(r => String(r[1]).trim())`
+
+- scripts\SyncLogic.gs:461 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const valsA = pre.getRange(linhaIni, 1, last - linhaIni + 1, 1).getDisplayValues();`
+
+- scripts\SyncLogic.gs:463 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_0
+  
+    Code: `if (CONFIG.STATUS.MARCADOR_BASE.test(valsA[i][0])) {`
+
+- scripts\SyncLogic.gs:497 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_9
+  
+    Code: `range: abaPedidos.getRange(obterLinhaInicialPorAba(CONFIG.SHEETS.PEDIDOS), 1, abaPedidos.getLastRow(), 9),`
+
+- scripts\SyncLogic.gs:522 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const registrosInfo = info.getRange(linhaInicialInfo, 1, lastInfo - linhaInicialInfo + 1, maxColInfo).getValues();`
+
+- scripts\SyncLogic.gs:542 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_0
+  
+    Code: `? pre.getRange(linhaHeaderPre, 1, 1, lastColPre).getDisplayValues()[0]`
+
+- scripts\SyncLogic.gs:542 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_0
+  
+    Code: `? pre.getRange(linhaHeaderPre, 1, 1, lastColPre).getDisplayValues()[0]`
+
+- scripts\SyncLogic.gs:559 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_2
+  
+    Code: `const dadosPre = pre.getRange(linhaInicialPre, 1, lastPre - linhaInicialPre + 1, 2).getDisplayValues();`
+
+- scripts\SyncLogic.gs:602 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const origem = pre.getRange(linhaMolde, 1, 1, maxCols);`
+
+- scripts\SyncLogic.gs:603 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const alvo = pre.getRange(linhaInicialPre, 1, qtd, maxCols);`
+
+- scripts\SyncLogic.gs:658 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_0
+  
+    Code: `const minRow = linhas[0];`
+
+- scripts\SyncLogic.gs:674 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `pre.getRange(minRow, 2, maxRow - minRow + 1, 1).clearDataValidations();`
+
+- scripts\SyncLogic.gs:693 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const valoresA = abaPedidos.getRange(linhaInicial, 1, limiteBusca - linhaInicial + 1, 1).getDisplayValues();`
+
+- scripts\SyncLogic.gs:717 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const valsA = aba.getRange(linhaInicial, 1, last - linhaInicial + 1, 1).getDisplayValues();`
+
+- scripts\SyncLogic.gs:752 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dados = info.getRange(linhaIniInfo, 1, numLinhas, numCols).getDisplayValues();`
+
+- scripts\SyncLogic.gs:835 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_0
+  
+    Code: `const emp = String(existentes[i][0]).trim().toUpperCase();`
+
+- scripts\SyncLogic.gs:836 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const uni = String(existentes[i][1]).trim();`
+
+- scripts\SyncLogic.gs:843 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_0
+  
+    Code: `const emp = String(listaEmpUni[i][0]).trim();`
+
+- scripts\SyncLogic.gs:844 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const uni = String(listaEmpUni[i][1]).trim();`
+
+- scripts\SyncLogic.gs:894 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_0
+  
+    Code: `const c = String(chavesObra[i][0]).trim();`
+
+- scripts\SyncLogic.gs:911 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_0
+  
+    Code: `const chavePed = String(chavesPedidos[i][0]).trim();`
+
+- scripts\SyncLogic.gs:972 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_2
+  
+    Code: `const dados = sheet.getRange(rowStart, 1, numRows, 2).getValues();`
+
+- scripts\SyncLogic.gs:1001 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dadosOco = abaOco.getRange(iniOco, 1, lastOco - iniOco + 1, Math.max(C_OCO.EMP, C_OCO.UNI, C_OCO.STATUS_GERAL)).getValues();`
+
+- scripts\SyncLogic.gs:1024 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const rangePre = abaPre.getRange(iniPre, 1, numRowsPre, maxColPre);`
+
+- scripts\SyncLogic.gs:1071 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dadosPre = pre.getRange(iniPre, 1, lastPre - iniPre + 1, maxColPre).getValues();`
+
+- scripts\SyncLogic.gs:1100 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const rangeInfo = info.getRange(iniInfo, 1, lastInfo - iniInfo + 1, Math.max(C_INFO.EMP, C_INFO.UNI));`
+
+- scripts\SyncLogic.gs:1162 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dadosEdicao = abaPedidos.getRange(rowStart, 1, numRows, abaPedidos.getLastColumn()).getValues();`
+
+- scripts\SyncLogic.gs:1184 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const rangeObra = abaObra.getRange(iniObra, 1, lastObra - iniObra + 1, C_OBRA.CHAVE);`
+
+- scripts\SyncLogic.gs:1223 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_9
+  
+    Code: `range: abaPedidos.getRange(obterLinhaInicialPorAba(CONFIG.SHEETS.PEDIDOS), 1, abaPedidos.getLastRow(), 9),`
+
+- scripts\SyncLogic.gs:1255 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dadosEntrega = entrega.getRange(rowStart, 1, numRows, Math.max(C_ENTREGA.EMP, C_ENTREGA.UNI)).getValues();`
+
+- scripts\SyncLogic.gs:1263 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dadosPre = pre.getRange(preIni, 1, preLast - preIni + 1, Math.max(C_PRE.EMP, C_PRE.UNI, C_PRE.RESP_OPR, C_PRE.RESP_ADM)).getValues();`
+
+- scripts\SyncLogic.gs:1313 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `range: entrega.getRange(ini, 1, last - ini + 1, 1), // simula alcance englobando coluna A (EMP)`
+
+- scripts\SyncLogic.gs:1420 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dados = abaPre.getRange(ini, 1, last - ini + 1, Math.max(C.EMP, C.UNI, C.DATA_LOTE)).getValues();`
+
+- scripts\SyncLogic.gs:1461 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dados   = sheetObra.getRange(rowStart, 1, numRows, numCols).getValues();`
+
+- scripts\SyncLogic.gs:1528 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dadosEnt = entrega.getRange(iniEnt, 1, lastEnt - iniEnt + 1, Math.max(C_ENT.UNI, C_ENT.STATUS_GERAL || 0)).getValues();`
+
+- scripts\SyncLogic.gs:1543 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const rangeInfo = info.getRange(iniInfo, 1, lastInfo - iniInfo + 1, Math.max(C_INFO.EMP, C_INFO.UNI));`
+
+- scripts\SyncLogic.gs:1576 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `range: obra.getRange(ini, 1, last - ini + 1, 1),`
+
+- scripts\SyncLogic.gs:1670 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `{ range: obra.getRange(ini, 1, last - ini + 1, 1), source: ss },`
+
+- scripts\SyncLogic.gs:1703 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const fakeEvent = { range: info.getRange(iniInfo, 1, lastInfo - iniInfo + 1, 1) };`
+
+- scripts\SyncLogic.gs:1732 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dadosInfo = info.getRange(rowStart, 1, numRows, maxColInfo).getDisplayValues();`
+
+- scripts\SyncLogic.gs:1757 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dadosObra = obra.getRange(iniObra, 1, numObraRows, maxColObra).getValues();`
+
+- scripts\SyncLogic.gs:1824 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dados = sheetObra.getRange(rowStart, 1, numRows, maxCol).getValues();`
+
+- scripts\SyncLogic.gs:1850 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `range: obra.getRange(ini, 1, last - ini + 1, 1),`
+
+- scripts\SyncLogic.gs:1882 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dadosInfo = abaInfo.getRange(iniInfo, 1, lastInfo - iniInfo + 1, maxColInfo).getDisplayValues();`
+
+- scripts\SyncLogic.gs:1905 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dadosPre = abaPre.getRange(iniPre, 1, lastPre - iniPre + 1, maxColPre).getDisplayValues();`
+
+- scripts\SyncLogic.gs:1914 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_999999
+  
+    Code: `etiquetas.push([999999]); // Marcador vai pro fundo absoluto`
+
+- scripts\SyncLogic.gs:1923 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_99999
+  
+    Code: `etiquetas.push([99999]); // Itens não listados, brancos ou lixos caem pro fundo`
+
+- scripts\SyncLogic.gs:1936 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const rangeTotal = abaPre.getRange(iniPre, 1, etiquetas.length, colTemp);`
+
+- scripts\Tests.gs:79 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_0
+  
+    Code: `sheetObra.getRange(novaLinhaObra, 1, 1, dadosTesteObra[0].length).setValues(dadosTesteObra);`
+
+- scripts\Tests.gs:83 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `range: sheetObra.getRange(novaLinhaObra, 1, 1, C_OBRA.ATRELADO),`
+
+- scripts\Tests.gs:94 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dadosPedidos = abaPedidos.getRange(iniPed, 1, Math.max(1, lastPed - iniPed + 1), C_PED.EMP).getDisplayValues();`
+
+- scripts\Tests.gs:116 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dadosPedidos2Before = abaPedidos.getRange(iniPed, 1, Math.max(1, lastPed2Before - iniPed + 1), C_PED.EMP).getDisplayValues();`
+
+- scripts\Tests.gs:125 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_0
+  
+    Code: `sheetObra.getRange(novaLinhaObra2, 1, 1, dadosTesteObra2[0].length).setValues(dadosTesteObra2);`
+
+- scripts\Tests.gs:128 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `range: sheetObra.getRange(novaLinhaObra2, 1, 1, C_OBRA.ATRELADO),`
+
+- scripts\Tests.gs:136 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dadosPedidos2After = abaPedidos.getRange(iniPed, 1, Math.max(1, lastPed2After - iniPed + 1), C_PED.EMP).getDisplayValues();`
+
+- scripts\Tests.gs:364 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const status = dados[i][1];`
+
+- scripts\Utils.gs:71 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dia = Number(m[1]);`
+
+- scripts\Utils.gs:72 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_2
+  
+    Code: `const mes = Number(m[2]) - 1;`
+
+- scripts\Utils.gs:73 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_3
+  
+    Code: `let ano = Number(m[3]);`
+
+- scripts\Utils.gs:110 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_0
+  
+    Code: `const cabecalhos = aba.getRange(linhaBusca, 1, 1, lastCol).getDisplayValues()[0];`
+
+- scripts\Utils.gs:110 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_0
+  
+    Code: `const cabecalhos = aba.getRange(linhaBusca, 1, 1, lastCol).getDisplayValues()[0];`
+
+- scripts\Utils.gs:143 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dados = aba.getRange(linhaInicialDados, 1, numRows, lastCol).getDisplayValues();`
+
+- scripts\Utils.gs:220 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_0
+  
+    Code: `if (String(values[i][0]).trim() !== "") return i + 1;`
+
+- scripts\Utils.gs:385 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dadosInfo = info.getRange(iniInfo, 1, lastInfo - iniInfo + 1, maxColInfo).getDisplayValues();`
+
+- scripts\Utils.gs:399 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const dadosChaveObra = obra.getRange(iniObra, 1, total, maxColChave).getDisplayValues();`
+
+- scripts\Utils.gs:444 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const rangeSort = obra.getRange(iniObra, 1, total, colSeqGlobal);`
+
+- scripts\Utils.gs:459 — pattern: getRange_numeric — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `const spacerRange = obra.getRange(spacerRow, 1, 1, obra.getLastColumn());`
+
+- scripts\Utils.gs:460 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_0
+  
+    Code: `const spacerVals = spacerRange.getValues()[0];`
+
+- tests.js:230 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_0
+  
+    Code: `suite4.assertEqual(dados[0][0], "EMPREENDIMENTO", "Cabeçalho correto");`
+
+- tests.js:231 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `suite4.assertEqual(dados[1][0], "MODERN BUNTANTÃ", "Primeiro EMP correto");`
+
+- tests.js:239 — pattern: array_index — suggestion: SUGGESTED_HEADER_COL_1
+  
+    Code: `suite4.assertEqual(dados[1][1], "11999999999", "Contato do primeiro fornecedor");`
+
+
+
+Suggested next steps:
+- For each occurrence, inspect and replace numeric index with resolveSheetColumns_(sheet, CONFIG.HEADERS_COLS.<SHEET>, CONFIG.COLUMNS.<SHEET>).
+- Add a descriptive key to CONFIG.HEADERS_COLS for the header text you will use.

--- a/scripts/SheetInfoGerais.gs
+++ b/scripts/SheetInfoGerais.gs
@@ -246,9 +246,9 @@ function configurarColunaEnviarEntregaInfoGerais() {
 
   const linhaHeader = obterLinhaInicialPorAba(CONFIG.SHEETS.INFO_GERAIS) - 1;
 
-  // Se não existir, cria após RESP ADM (Col 10)
+  // Se não existir, cria após RESP ADM (usa C.RESP_ADM como base quando disponível, senão 10)
   if (colAlvo <= 0) {
-    const colBase = 10; // RESP ADM
+    const colBase = (C.RESP_ADM && C.RESP_ADM > 0) ? C.RESP_ADM : 10; // RESP ADM (header-resolved)
     info.insertColumnsAfter(colBase, 1);
     colAlvo = colBase + 1;
     info.getRange(linhaHeader, colAlvo).setValue("ENVIAR FASE-ENTREGA");

--- a/scripts/SyncLogic.gs
+++ b/scripts/SyncLogic.gs
@@ -1075,9 +1075,20 @@ function sincronizarInformacoesGeraisDesdePreliminar_(exibirAlerta) {
     const emp = String(dadosPre[i][C_PRE.EMP - 1]).trim().toUpperCase();
     const uni = String(dadosPre[i][C_PRE.UNI - 1]).trim();
     if (emp && uni) {
+      // Normaliza valores vindos da Preliminar: trata explicitamente o texto "LIMPO"
+      let pend = C_PRE.RESUMO_PENDENCIAS > 0 ? dadosPre[i][C_PRE.RESUMO_PENDENCIAS - 1] : "";
+      let oco  = C_PRE.RESUMO_OCORRENCIAS  > 0 ? dadosPre[i][C_PRE.RESUMO_OCORRENCIAS  - 1] : "";
+
+      try {
+        if (typeof pend === 'string' && pend.trim().toUpperCase() === 'LIMPO') pend = "";
+      } catch (e) { /* noop */ }
+      try {
+        if (typeof oco === 'string' && oco.trim().toUpperCase() === 'LIMPO') oco = "";
+      } catch (e) { /* noop */ }
+
       mapaDados.set(`${emp}|${uni}`, {
-        pendencias: C_PRE.RESUMO_PENDENCIAS > 0 ? dadosPre[i][C_PRE.RESUMO_PENDENCIAS - 1] : "",
-        ocorrencias: C_PRE.RESUMO_OCORRENCIAS > 0 ? dadosPre[i][C_PRE.RESUMO_OCORRENCIAS - 1] : ""
+        pendencias: pend,
+        ocorrencias: oco
       });
     }
   }


### PR DESCRIPTION
Substitui índice fixo da coluna RESP_ADM pelo valor resolvido via resolveSheetColumns_. Parte do esforço de remapear índices numéricos para nomes de cabeçalho.