### PR TITLE
refactor(obra): usar maxCols para evitar indices fixos

### DIFF
--- a/scripts/SheetObra.gs
+++ b/scripts/SheetObra.gs
@@ -224,7 +224,20 @@ function gerarTemplatesPendentesFaseObra() {
 
     let unidadesAbertas = 0;
     const arrayLoteCompleto = [];
-    const numMaxColsLinha = C_OBRA.CHAVE;
+    const maxColsObra = Math.max(
+      C_OBRA.CHAVE || 0,
+      C_OBRA.EMP || 0,
+      C_OBRA.UNI || 0,
+      C_OBRA.OPR || 0,
+      C_OBRA.ADM || 0,
+      C_OBRA.TIPO || 0,
+      C_OBRA.CAT || 0,
+      C_OBRA.SUB || 0,
+      C_OBRA.ATRELADO || 0,
+      C_OBRA.DATA_SOLICITADO_OPR || 0,
+      C_OBRA.DATA_AGENDADO_ADM || 0
+    );
+    const numMaxColsLinha = Math.max(1, maxColsObra);
 
     // 2) Constrói as linhas virtualmente na memória
     for (let i = 0; i < dadosPre.length; i++) {


### PR DESCRIPTION
Refatora SheetObra para usar cálculos de larguras (maxCols) baseados em resolveSheetColumns_, evitando getRange com índices numéricos fixos.\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>