### PR TITLE
feat(agent-logs): append logs on push

### DIFF
--- a/.github/workflows/agent-log-on-push.yml
+++ b/.github/workflows/agent-log-on-push.yml
@@ -1,0 +1,75 @@
+name: Append AGENT-LOG on Push
+
+on:
+  push:
+    # ignore commits made by agent-log itself via commit message check/actor guard
+    branches: ['**']
+
+jobs:
+  append-log:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Append AGENT log entry for push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eu
+
+          # Avoid infinite loops: if this workflow was triggered by a commit from GitHub Actions, skip
+          if [ "${GITHUB_ACTOR}" = "github-actions[bot]" ] || [ "${GITHUB_ACTOR}" = "github-actions" ]; then
+            echo "Triggered by GitHub Actions actor (${GITHUB_ACTOR}) - skipping agent-log append."
+            exit 0
+          fi
+
+          # Skip if last commit message already indicates agent-log
+          LAST_MSG=$(git log -1 --pretty=%B || true)
+          if echo "$LAST_MSG" | grep -qi "agent-log:"; then
+            echo "Last commit appears to be agent-log. Skipping to avoid loop."
+            exit 0
+          fi
+
+          TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          BRANCH=${GITHUB_REF#refs/heads/}
+          ENTRY="- ${TS} | PushAgent | PUSH | branch:${BRANCH} | commit: ${GITHUB_SHA}"
+
+          if [ ! -f AGENT-LOGS.md ]; then
+            echo "# AGENT-LOGS" > AGENT-LOGS.md
+            echo "(Autogerado pelo workflow agent-log-on-push)" >> AGENT-LOGS.md
+            echo "" >> AGENT-LOGS.md
+          fi
+
+          echo "$ENTRY" >> AGENT-LOGS.md
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add AGENT-LOGS.md
+
+          if git diff --staged --quiet; then
+            echo "No changes to commit."
+            exit 0
+          fi
+
+          COMMIT_MSG="agent-log: ${TS} PUSH ${BRANCH} ${GITHUB_SHA}"
+          git commit -m "$COMMIT_MSG" || true
+
+          # Try to push to the same branch. If it fails (protected branch), push to a fallback branch.
+          if git push origin HEAD:"${BRANCH}"; then
+            echo "Agent log appended and pushed to ${BRANCH}"
+          else
+            FALLBACK_BRANCH="agent-log/push-${GITHUB_SHA:0:7}-$(date -u +%Y%m%d%H%M%S)"
+            echo "Push to ${BRANCH} failed; pushing to fallback branch ${FALLBACK_BRANCH}"
+            git push origin HEAD:"${FALLBACK_BRANCH}" || true
+            echo "Fallback branch pushed: ${FALLBACK_BRANCH}. Please review/merge to consolidate logs."
+          fi
+
+      - name: Done
+        run: echo "agent-log-on-push finished"

--- a/AGENT-LOGS.md
+++ b/AGENT-LOGS.md
@@ -45,3 +45,4 @@ Obs: este arquivo foi criado automaticamente para suportar monitoramento entre a
 - 2026-04-10T15:52:05Z | agent-log-retrofit | PR-MERGED | refactor(obra): usar maxCols para evitar indices fixos | commit: 148229e | pr: #18
 - 2026-04-10T16:10:13Z | PushAgent | PUSH | branch:chore/agent-log-on-push | commit: 220e5ab24e801f2271e41426fea78bfce70918a8
 - 2026-04-10T16:18:05Z | PushAgent | PUSH | branch:chore/agent-log-on-push | commit: d77b5ef321982836ef4b637b8878e3d391b43a06
+- 2026-04-10T16:30:46Z | PushAgent | PUSH | branch:chore/agent-log-on-push | commit: 0a482189eacf0a942770bbfcd71c4b9cbfc033a3

--- a/AGENT-LOGS.md
+++ b/AGENT-LOGS.md
@@ -46,3 +46,4 @@ Obs: este arquivo foi criado automaticamente para suportar monitoramento entre a
 - 2026-04-10T16:10:13Z | PushAgent | PUSH | branch:chore/agent-log-on-push | commit: 220e5ab24e801f2271e41426fea78bfce70918a8
 - 2026-04-10T16:18:05Z | PushAgent | PUSH | branch:chore/agent-log-on-push | commit: d77b5ef321982836ef4b637b8878e3d391b43a06
 - 2026-04-10T16:30:46Z | PushAgent | PUSH | branch:chore/agent-log-on-push | commit: 0a482189eacf0a942770bbfcd71c4b9cbfc033a3
+- 2026-04-10T16:58:56Z | PushAgent | PUSH | branch:chore/agent-log-on-push | commit: 7f92d482e4f5876d5b77fc1a0a4a2835e0ac0801

--- a/AGENT-LOGS.md
+++ b/AGENT-LOGS.md
@@ -47,3 +47,4 @@ Obs: este arquivo foi criado automaticamente para suportar monitoramento entre a
 - 2026-04-10T16:18:05Z | PushAgent | PUSH | branch:chore/agent-log-on-push | commit: d77b5ef321982836ef4b637b8878e3d391b43a06
 - 2026-04-10T16:30:46Z | PushAgent | PUSH | branch:chore/agent-log-on-push | commit: 0a482189eacf0a942770bbfcd71c4b9cbfc033a3
 - 2026-04-10T16:58:56Z | PushAgent | PUSH | branch:chore/agent-log-on-push | commit: 7f92d482e4f5876d5b77fc1a0a4a2835e0ac0801
+- 2026-04-10T17:29:55Z | PushAgent | PUSH | branch:chore/agent-log-on-push | commit: cde82c40317c1459367d83ddf7f5287f6759789a

--- a/AGENT-LOGS.md
+++ b/AGENT-LOGS.md
@@ -43,3 +43,4 @@ Obs: este arquivo foi criado automaticamente para suportar monitoramento entre a
 - 2026-04-10T15:39:29Z | agent-log-retrofit | PR-MERGED | chore(agent-logs): add workflow and retrofit logs for PRs #13,#14 | commit: 0bcd112 | pr: #16
 - 2026-04-10T15:46:43Z | agent-log-retrofit | PR-MERGED | fix(workflow): corrigir sintaxe agent-log-on-merge.yml | commit: eba857b | pr: #17
 - 2026-04-10T15:52:05Z | agent-log-retrofit | PR-MERGED | refactor(obra): usar maxCols para evitar indices fixos | commit: 148229e | pr: #18
+- 2026-04-10T16:10:13Z | PushAgent | PUSH | branch:chore/agent-log-on-push | commit: 220e5ab24e801f2271e41426fea78bfce70918a8

--- a/AGENT-LOGS.md
+++ b/AGENT-LOGS.md
@@ -44,3 +44,4 @@ Obs: este arquivo foi criado automaticamente para suportar monitoramento entre a
 - 2026-04-10T15:46:43Z | agent-log-retrofit | PR-MERGED | fix(workflow): corrigir sintaxe agent-log-on-merge.yml | commit: eba857b | pr: #17
 - 2026-04-10T15:52:05Z | agent-log-retrofit | PR-MERGED | refactor(obra): usar maxCols para evitar indices fixos | commit: 148229e | pr: #18
 - 2026-04-10T16:10:13Z | PushAgent | PUSH | branch:chore/agent-log-on-push | commit: 220e5ab24e801f2271e41426fea78bfce70918a8
+- 2026-04-10T16:18:05Z | PushAgent | PUSH | branch:chore/agent-log-on-push | commit: d77b5ef321982836ef4b637b8878e3d391b43a06


### PR DESCRIPTION
Adiciona workflow que anexa automaticamente uma linha em AGENT-LOGS.md para cada push (exceto commits feitos pelo Actions). Evita loops detectando actor/commit message e empurra para o mesmo branch; cria branch fallback se push for bloqueado por proteção.\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>