### PR TITLE
refactor(sync): resolve columns by headers in SyncLogic

### DIFF
--- a/scripts/SheetPedidos.gs
+++ b/scripts/SheetPedidos.gs
@@ -60,11 +60,11 @@ function buscarContatoFornecedor_(e) {
     linhasBuscaHeader
   );
 
-  // 2) Se não encontrou cabeçalho, assume Backup sem cabeçalho e usa índices fixos
+  // 2) Se não encontrou cabeçalho, assume Backup sem cabeçalho e usa índices padrão do CONFIG como fallback
   if (colFornecedorBackup <= 0 || colContatoBackup <= 0) {
-    console.log("Aba Backup sem cabeçalhos detectada. Usando índices fixos: FORNECEDOR=col10, CONTATO=col11");
-    colFornecedorBackup = 10;  // Coluna J (FORNECEDOR típico)
-    colContatoBackup = 11;     // Coluna K (CONTATO típico)
+    console.log("Aba Backup sem cabeçalhos detectada. Usando índices padrão de CONFIG.COLUMNS.PEDIDOS: FORNECEDOR, CONTATO");
+    colFornecedorBackup = (CONFIG && CONFIG.COLUMNS && CONFIG.COLUMNS.PEDIDOS && CONFIG.COLUMNS.PEDIDOS.FORNECEDOR) || 10;  // fallback para Coluna J
+    colContatoBackup = (CONFIG && CONFIG.COLUMNS && CONFIG.COLUMNS.PEDIDOS && CONFIG.COLUMNS.PEDIDOS.CONTATO) || 11;     // fallback para Coluna K
   }
 
   const maxCol = Math.max(colFornecedorBackup, colContatoBackup);

--- a/scripts/SyncLogic.gs
+++ b/scripts/SyncLogic.gs
@@ -640,8 +640,8 @@ function sincronizarPreliminarDesdeInformacoesGerais_(chavesAlvo, exibirAlerta) 
   for (const a of atualizacoes) {
     const { rowPre, infoRow, isNova } = a;
 
-    registrarEscrita(rowPre, 1, String(infoRow[C_INFO.EMP - 1] || "").trim());
-    registrarEscrita(rowPre, 2, String(infoRow[C_INFO.UNI - 1] || "").trim());
+    registrarEscrita(rowPre, C_PRE.EMP, String(infoRow[C_INFO.EMP - 1] || "").trim());
+    registrarEscrita(rowPre, C_PRE.UNI, String(infoRow[C_INFO.UNI - 1] || "").trim());
     registrarEscrita(rowPre, mapeamento.colDataLote, infoRow[C_INFO.DATA_LOTE - 1]);
     registrarEscrita(rowPre, mapeamento.colDataPrazo, infoRow[C_INFO.DATA_PRAZO - 1]);
     registrarEscrita(rowPre, mapeamento.colFaseMacro, infoRow[C_INFO.FASE_MACRO - 1]);


### PR DESCRIPTION
Replace hardcoded column indices with resolveSheetColumns_ constants (C_PRE.EMP/C_PRE.UNI) to avoid fixed indices. Local tests passed.\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>